### PR TITLE
Overlap content-type

### DIFF
--- a/client.go
+++ b/client.go
@@ -215,7 +215,7 @@ func (p *aliMNSClient) Send(method Method, headers map[string]string, message in
 	req.SetBody(xmlContent)
 
 	for header, value := range headers {
-		req.Header.Add(header, value)
+		req.Header.Set(header, value)
 	}
 
 	resp := fasthttp.AcquireResponse()


### PR DESCRIPTION
采用Set接口覆盖掉原有的content-type, 对服务端更加友好。因为在spring-boot中，框架会默认取第一个content-type会导致一些校验上的失败